### PR TITLE
chore: Bump version to 0.1.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-scanner (0.1.4) unstable; urgency=medium
+
+  * Update version to 0.1.4
+  * Fix some UI issues.
+
+ -- re2zero <yangwu@uniontech.com>  Wed, 14 May 2025 13:03:16 +0800
+
 deepin-scanner (0.1.3) unstable; urgency=medium
 
   * Update version to 0.1.3


### PR DESCRIPTION
New tag v0.1.4 release.

Log: Bump version to 0.1.4