### PR TITLE
fix: add trailing semicolon to Categories field in desktop file

### DIFF
--- a/resources/deepin-scanner.desktop
+++ b/resources/deepin-scanner.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Categories=Utility;Application
+Categories=Utility;Application;
 Comment=Scanner Manager is a scanner tool that supports a variety of scanning devices
 Exec=deepin-scanner
 GenericName=Scanner Manager


### PR DESCRIPTION
Fix desktop entry Categories field to comply with freedesktop.org specification by adding trailing semicolon.

修复桌面入口文件中Categories字段，添加末尾分号以符合
freedesktop.org规范要求。

Log: 修复desktop文件Categories字段语法
PMS: BUG-366913
Influence: 修复桌面环境分类匹配问题，确保应用可被正确分类过滤。

## Summary by Sourcery

Bug Fixes:
- Correct the Categories field in the desktop file so it includes the required trailing semicolon, restoring proper desktop environment category matching.