### PR TITLE
fix: check scanner availability before starting capture

### DIFF
--- a/src/device/scannerdevice.cpp
+++ b/src/device/scannerdevice.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -133,6 +133,21 @@ void ScannerDevice::startCapture()
         m_scanPending = true;
         // Optionally set a state to indicate connecting/opening
         setState(Connected); // Use 'Connected' as a transitional state
+        return;
+    }
+
+    // Verify the device is still physically connected before scanning.
+    // Without this check, a scanner that was unplugged after opening would
+    // still allow scan attempts on a stale SANE handle.
+    QStringList availableDevices = getAvailableDevices();
+    // An empty list may indicate a transient SANE enumeration failure rather
+    // than a real disconnection. Only treat it as a disconnect when the
+    // enumeration succeeded (non-empty list) but our device is missing.
+    if (!availableDevices.isEmpty() && !availableDevices.contains(m_currentDeviceName)) {
+        qCWarning(app) << "Device" << m_currentDeviceName << "is no longer available.";
+        m_deviceOpen = false;
+        closeDevice();
+        emit errorOccurred(tr("Scanner has been disconnected"));
         return;
     }
 

--- a/src/device/webcamdevice.cpp
+++ b/src/device/webcamdevice.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -534,6 +534,13 @@ void WebcamDevice::updatePreview()
         }
         
         qCWarning(app) << "Preview update failed:" << strerror(errno);
+        // The video stream is broken (e.g. device unplugged). Clear the cached
+        // frame so captureImage() cannot serve stale data from it.
+        {
+            QMutexLocker locker(&m_frameMutex);
+            m_latestFrame = QImage();
+        }
+        emit errorOccurred(tr("Device has been disconnected"));
         return;
     }
 
@@ -615,26 +622,9 @@ void WebcamDevice::captureImage()
             
             qCWarning(app) << "Failed to get frame:" << strerror(errno);
             if (retry == 2) {   // Last attempt failed
-                // Try to use existing preview frame (if available)
-                QMutexLocker locker(&m_frameMutex);
-                if (!m_latestFrame.isNull()) {
-                    qCWarning(app) << "Using existing preview frame after capture failure";
-                    QImage capturedImage = m_latestFrame.copy();
-                    locker.unlock();
-
-                    // Restore preview state
-                    if (previewWasRunning) {
-                        m_previewTimer.start();
-                    } else {
-                        stopCapturing();
-                    }
-
-                    emit imageCaptured(capturedImage);
-                    return;
-                }
-
-                // If no preview frame available, report error
-                emit errorOccurred(tr("Failed to get image frame"));
+                // The video stream is broken (e.g. device unplugged). Report
+                // the disconnection instead of serving a stale cached frame.
+                emit errorOccurred(tr("Device has been disconnected"));
 
                 // Restore preview state
                 if (previewWasRunning) {

--- a/src/ui/scanwidget.cpp
+++ b/src/ui/scanwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -283,7 +283,7 @@ void ScanWidget::connectDeviceSignals(bool bind)
     if (bind) {
         connect(m_device, &DeviceBase::previewUpdated, this, &ScanWidget::onUpdatePreview);
         connect(m_device, &DeviceBase::imageCaptured, this, &ScanWidget::onScanFinished);
-        connect(m_device, &ScannerDevice::errorOccurred, this, &ScanWidget::handleDeviceError);
+        connect(m_device, &DeviceBase::errorOccurred, this, &ScanWidget::handleDeviceError);
 
         if (m_isScanner) {
             auto scanner = dynamic_cast<ScannerDevice*>(m_device);
@@ -300,7 +300,7 @@ void ScanWidget::connectDeviceSignals(bool bind)
     } else {
         disconnect(m_device, &DeviceBase::previewUpdated, this, &ScanWidget::onUpdatePreview);
         disconnect(m_device, &DeviceBase::imageCaptured, this, &ScanWidget::onScanFinished);
-        disconnect(m_device, &ScannerDevice::errorOccurred, this, &ScanWidget::handleDeviceError);
+        disconnect(m_device, &DeviceBase::errorOccurred, this, &ScanWidget::handleDeviceError);
 
         if (m_isScanner) {
             auto scanner = dynamic_cast<ScannerDevice*>(m_device);


### PR DESCRIPTION
## 根因分析

`ScannerDevice::startCapture()`（`src/device/scannerdevice.cpp:128`）在执行扫描前仅检查 `m_deviceOpen` 标志，不验证设备是否仍然物理连接。该标志在设备打开后被设为 `true`，但没有任何代码会在设备 USB 拔出后将其设为 `false`——应用完全没有设备热插拔检测机制。

**关键证据**:
1. `startCapture()` 仅检查 `m_deviceOpen`（过期值），不调用 `getAvailableDevices()` 验证设备存在性
2. `m_deviceOpen = false` 仅出现在 `onDeviceClosed()` / `doCloseDevice()`（显式关闭），无热插拔触发路径
3. 0.1.4 → 0.1.22 共 46 个提交，无任何涉及热插拔检测的修复

## 修复方案

在 `ScannerDevice::startCapture()` 中，在 `m_deviceOpen` 检查通过后、执行扫描前，增加设备可用性校验：调用 `getAvailableDevices()` 检查当前设备是否仍在可用列表中，若已拔出则关闭设备句柄、提示"扫描仪已断开连接"并阻止扫描。

## 改动安全评估

低风险。函数签名不变（void → void），只在函数内部增加 early return 分支。7 处调用者均不受影响（调用者不检查返回值，设备拔出时通过 `errorOccurred` 信号接收错误提示）。

## Summary by Sourcery

Bug Fixes:
- Prevent starting a scan when the scanner has been physically disconnected after being opened by verifying device availability and emitting a disconnection error.