### PR TITLE
fix: prevent zip slip path traversal in OFD extraction

### DIFF
--- a/src/libofd/src/ofd_reader.cpp
+++ b/src/libofd/src/ofd_reader.cpp
@@ -48,6 +48,9 @@ bool Reader::uncompressFile(const QString &path, const QString &extractPath)
         return false;
     }
 
+    // 规范化解压根目录，用于 Zip Slip（路径穿越）防护
+    const QString cleanRoot = QDir::cleanPath(extractPath);
+
     for (bool f = zip.goToFirstFile(); f; f = zip.goToNextFile()) {
         QuaZipFile zipFile(&zip);
         if (!zipFile.open(QIODevice::ReadOnly)) {
@@ -55,7 +58,15 @@ bool Reader::uncompressFile(const QString &path, const QString &extractPath)
             return false;
         }
 
-        QString filePath = extractPath + QDir::separator() + zip.getCurrentFileName();
+        // 拼接并规范化目标路径，解析条目名中的 "."/".."，防止逃逸出解压根目录
+        QString filePath = QDir::cleanPath(cleanRoot + QLatin1Char('/') + zip.getCurrentFileName());
+
+        // 校验目标路径必须位于解压根目录之内，否则跳过该条目（不创建目录、不写入）
+        if (!filePath.startsWith(cleanRoot + QLatin1Char('/'), Qt::CaseSensitive)) {
+            zipFile.close();
+            continue;
+        }
+
         QFileInfo fileInfo(filePath);
         QDir().mkpath(fileInfo.path());
 


### PR DESCRIPTION
## 根因分析

`Reader::uncompressFile`（`src/libofd/src/ofd_reader.cpp`）在解压 OFD（zip）文档时，将攻击者可控的 zip 条目名 `zip.getCurrentFileName()` 直接拼接到解压根目录之后作为写入路径，未做规范化或目录限制，并在写入前以 `QDir().mkpath()` 为该路径创建父目录。当条目名包含 `../` 序列时，写入目标逃逸出解压根目录，可落到 `~/.config/autostart/`、`~/.bashrc` 等受保护位置，形成 Zip Slip 路径穿越漏洞（任意可写路径文件写入/覆盖）。

关键证据：
- `ofd_reader.cpp:58` — `filePath = extractPath + QDir::separator() + zip.getCurrentFileName()`，条目名直接拼接，无规范化、无目录限制。
- `ofd_reader.cpp:60/62-69` — `mkpath` 为逃逸路径建父目录，随后写入攻击者可控内容。
- `ofd_reader.cpp:19-41` + `examples/simple_example.cpp:31` — `Reader::readFile` 处理外部 OFD 输入，漏洞真实可达。

## 修复方案

在 `uncompressFile` 内对每个 zip 条目做「规范化 + 目录限制」校验：
1. 用 `QDir::cleanPath(extractPath)` 得到规范化解压根 `cleanRoot`。
2. 拼接后用 `QDir::cleanPath(cleanRoot + '/' + entryName)` 解析条目名中的 `.`/`..`。
3. 校验规范化后的目标路径必须以 `cleanRoot + "/"` 为前缀，否则跳过该条目（不创建目录、不写入）。

对合法 OFD（条目名为 `OFD.xml`、`Doc_0/Document.xml`、`Doc_0/Res/Image_1.png` 等相对路径）零影响，仅拦截含 `../`/绝对路径的恶意条目。

## 改动安全评估

低风险。仅修改 `uncompressFile` 内部逻辑，不改变函数签名、不改变返回值语义、不影响调用方（仅 2 处引用：`readFile` 调用点 + 头文件私有声明）。目标代码由单次提交 `bdf74e70`（feat: Support OFD file）引入，非既有 bug 修复产物，本次改动不撤销任何历史修复。

## Summary by Sourcery

Bug Fixes:
- Prevent path traversal during OFD zip extraction by rejecting entries that escape the configured extraction directory.